### PR TITLE
feat: add possibility to trigger deploy manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy-live-document:


### PR DESCRIPTION
This is preferable when the only thing that changed is the build configuration (in the related case, SIGNALING_SERVER_URL env var).